### PR TITLE
build:生成并上传 SHA-256 校验到release

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -229,7 +229,9 @@ jobs:
           mv artifacts/zed-linux-arm64.deb/zed-linux-arm64.deb zed-linux-arm64.deb
           mv artifacts/zed-linux-x86_64/zed-linux-x86_64.tar.gz zed-linux-x86_64.tar.gz
           mv artifacts/zed-linux-arm64/zed-linux-arm64.tar.gz zed-linux-arm64.tar.gz
-
+      - name: build sha256
+        run: |
+          sha256sum zed-windows.zip zed-linux-x86_64.deb zed-linux-arm64.deb zed-linux-x86_64.tar.gz zed-linux-arm64.tar.gz > sha256sums.txt
       - name: Upload release build artifacts to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -243,3 +245,4 @@ jobs:
             zed-linux-arm64.deb
             zed-linux-x86_64.tar.gz
             zed-linux-arm64.tar.gz
+            sha256sums.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,9 @@ jobs:
           mv artifacts/zed-linux-arm64.deb/zed-linux-arm64.deb zed-linux-arm64.deb
           mv artifacts/zed-linux-x86_64/zed-linux-x86_64.tar.gz zed-linux-x86_64.tar.gz
           mv artifacts/zed-linux-arm64/zed-linux-arm64.tar.gz zed-linux-arm64.tar.gz
-
+      - name: build sha256
+        run: |
+          sha256sum zed-windows.zip zed-linux-x86_64.deb zed-linux-arm64.deb zed-linux-x86_64.tar.gz zed-linux-arm64.tar.gz > sha256sums.txt
       - name: Upload release build artifacts to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -243,3 +245,4 @@ jobs:
             zed-linux-arm64.deb
             zed-linux-x86_64.tar.gz
             zed-linux-arm64.tar.gz
+            sha256sums.txt


### PR DESCRIPTION
生成并上传 SHA-256 校验到release，用于scoop自动化更新软件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release downloads now include a sha256sums.txt file containing SHA-256 checksums for all major release artifacts, making it easier to verify file integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->